### PR TITLE
Append V6 to deploy salts

### DIFF
--- a/script/ConfigureFeeProject.s.sol
+++ b/script/ConfigureFeeProject.s.sol
@@ -75,9 +75,9 @@ contract ConfigureFeeProjectScript is Script, Sphinx {
     uint32 ETH_CURRENCY = JBCurrencyIds.ETH;
     uint8 DECIMALS = 18;
     uint256 DECIMAL_MULTIPLIER = 10 ** DECIMALS;
-    bytes32 SUCKER_SALT = "_CPN_SUCKER__";
-    bytes32 ERC20_SALT = "_CPN_ERC20_SALT__";
-    bytes32 HOOK_SALT = "_CPN_HOOK_SALT__";
+    bytes32 SUCKER_SALT = "_CPN_SUCKERV6__";
+    bytes32 ERC20_SALT = "_CPN_ERC20_SALTV6__";
+    bytes32 HOOK_SALT = "_CPN_HOOK_SALTV6__";
     address OPERATOR;
     address TRUSTED_FORWARDER;
     uint48 CPN_START_TIME = 1_740_089_444;

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -25,9 +25,9 @@ contract DeployScript is Script, Sphinx {
     uint256 FEE_PROJECT_ID = 0;
 
     /// @notice the salts that are used to deploy the contracts.
-    bytes32 PUBLISHER_SALT = "_PUBLISHER_SALT_";
-    bytes32 DEPLOYER_SALT = "_DEPLOYER_SALT_";
-    bytes32 PROJECT_OWNER_SALT = "_PROJECT_OWNER_SALT_";
+    bytes32 PUBLISHER_SALT = "_PUBLISHER_SALTV6_";
+    bytes32 DEPLOYER_SALT = "_DEPLOYER_SALTV6_";
+    bytes32 PROJECT_OWNER_SALT = "_PROJECT_OWNER_SALTV6_";
     address TRUSTED_FORWARDER;
 
     function configureSphinx() public override {


### PR DESCRIPTION
## Summary
- Updated `PUBLISHER_SALT`, `DEPLOYER_SALT`, `PROJECT_OWNER_SALT` with V6 suffix in `Deploy.s.sol`
- Updated `SUCKER_SALT`, `ERC20_SALT`, `HOOK_SALT` (CPN variants) with V6 suffix in `ConfigureFeeProject.s.sol`

Ensures all V6 contracts deploy to different deterministic addresses than V5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)