### PR TITLE
chore: v6 QC pass

### DIFF
--- a/src/CTDeployer.sol
+++ b/src/CTDeployer.sol
@@ -137,7 +137,7 @@ contract CTDeployer is ERC2771Context, JBPermissioned, IJBRulesetDataHook, IERC7
         override
         returns (uint256 weight, JBPayHookSpecification[] memory hookSpecifications)
     {
-        // Otherwise, forward the call to the datahook.
+        // Forward the call to the data hook.
         // slither-disable-next-line unused-return
         return dataHookOf[context.projectId].beforePayRecordedWith(context);
     }

--- a/src/CTPublisher.sol
+++ b/src/CTPublisher.sol
@@ -168,7 +168,7 @@ contract CTPublisher is JBPermissioned, ERC2771Context, ICTPublisher {
         minimumPrice = uint256(uint104(packed));
         // minimum supply in bits 104-135 (32 bits).
         minimumTotalSupply = uint256(uint32(packed >> 104));
-        // minimum supply in bits 136-67 (32 bits).
+        // maximum supply in bits 136-167 (32 bits).
         maximumTotalSupply = uint256(uint32(packed >> 136));
 
         allowedAddresses = _allowedAddresses[hook][category];

--- a/src/interfaces/ICTDeployer.sol
+++ b/src/interfaces/ICTDeployer.sol
@@ -11,10 +11,25 @@ import {CTSuckerDeploymentConfig} from "../structs/CTSuckerDeploymentConfig.sol"
 import {CTProjectConfig} from "../structs/CTProjectConfig.sol";
 
 interface ICTDeployer {
+    /// @notice The contract that mints ERC-721s representing Juicebox project ownership.
+    /// @return The projects contract.
     function PROJECTS() external view returns (IJBProjects);
+
+    /// @notice The deployer used to launch tiered ERC-721 hook collections.
+    /// @return The hook deployer contract.
     function DEPLOYER() external view returns (IJB721TiersHookDeployer);
+
+    /// @notice The Croptop publisher that manages posting criteria and minting.
+    /// @return The publisher contract.
     function PUBLISHER() external view returns (ICTPublisher);
 
+    /// @notice Deploy a simple Juicebox project configured to receive posts from Croptop templates.
+    /// @param owner The address that will own the project after deployment.
+    /// @param projectConfig The configuration for the project, including name, symbol, and allowed posts.
+    /// @param suckerDeploymentConfiguration The configuration for cross-chain suckers to deploy.
+    /// @param controller The controller that will manage the project.
+    /// @return projectId The ID of the newly created project.
+    /// @return hook The tiered ERC-721 hook that was deployed for the project.
     function deployProjectFor(
         address owner,
         CTProjectConfig calldata projectConfig,
@@ -24,8 +39,14 @@ interface ICTDeployer {
         external
         returns (uint256 projectId, IJB721TiersHook hook);
 
+    /// @notice Claim ownership of a tiered ERC-721 hook collection by transferring it to the project.
+    /// @param hook The hook to claim ownership of. The caller must own the project the hook belongs to.
     function claimCollectionOwnershipOf(IJB721TiersHook hook) external;
 
+    /// @notice Deploy new suckers for an existing project.
+    /// @param projectId The ID of the project to deploy suckers for.
+    /// @param suckerDeploymentConfiguration The suckers to set up for the project.
+    /// @return suckers The addresses of the deployed suckers.
     function deploySuckersFor(
         uint256 projectId,
         CTSuckerDeploymentConfig calldata suckerDeploymentConfiguration

--- a/src/interfaces/ICTProjectOwner.sol
+++ b/src/interfaces/ICTProjectOwner.sol
@@ -6,8 +6,19 @@ import {IJBProjects} from "@bananapus/core-v5/src/interfaces/IJBProjects.sol";
 
 import {ICTPublisher} from "./ICTPublisher.sol";
 
+/// @notice A contract that can receive a Juicebox project NFT (via `safeTransferFrom`) and automatically grants the
+/// Croptop publisher permission to manage the project's 721 tiers. Once the project is transferred to this contract,
+/// its ownership is effectively burned while still allowing croptop posts.
 interface ICTProjectOwner {
+    /// @notice The contract where operator permissions are stored.
+    /// @return The permissions contract.
     function PERMISSIONS() external view returns (IJBPermissions);
+
+    /// @notice The contract from which Juicebox projects are minted as ERC-721 tokens.
+    /// @return The projects contract.
     function PROJECTS() external view returns (IJBProjects);
+
+    /// @notice The Croptop publisher that manages posting criteria and minting.
+    /// @return The publisher contract.
     function PUBLISHER() external view returns (ICTPublisher);
 }

--- a/src/interfaces/ICTPublisher.sol
+++ b/src/interfaces/ICTPublisher.sol
@@ -21,14 +21,31 @@ interface ICTPublisher {
         address caller
     );
 
+    /// @notice The divisor that describes the fee percent. Equal to 100 divided by the fee percent.
+    /// @return The fee divisor.
     function FEE_DIVISOR() external view returns (uint256);
 
+    /// @notice The directory that contains the projects being posted to.
+    /// @return The directory contract.
     function DIRECTORY() external view returns (IJBDirectory);
 
+    /// @notice The ID of the project to which fees will be routed.
+    /// @return The fee project ID.
     function FEE_PROJECT_ID() external view returns (uint256);
 
+    /// @notice The tier ID that an IPFS metadata URI has been saved to for a given hook.
+    /// @param hook The hook for which the tier ID applies.
+    /// @param encodedIPFSUri The encoded IPFS URI to look up.
+    /// @return The tier ID, or 0 if the URI has not been published.
     function tierIdForEncodedIPFSUriOf(address hook, bytes32 encodedIPFSUri) external view returns (uint256);
 
+    /// @notice The post allowance for a particular category on a particular hook.
+    /// @param hook The hook contract for which this allowance applies.
+    /// @param category The category for which this allowance applies.
+    /// @return minimumPrice The minimum price a poster must pay to publish a new NFT.
+    /// @return minimumTotalSupply The minimum total supply a poster must set for a new NFT.
+    /// @return maximumTotalSupply The maximum total supply allowed for a new NFT. 0 means no limit.
+    /// @return allowedAddresses The addresses allowed to post. Empty if all addresses are allowed.
     function allowanceFor(
         address hook,
         uint256 category
@@ -42,6 +59,10 @@ interface ICTPublisher {
             address[] memory allowedAddresses
         );
 
+    /// @notice Get the tiers for the provided encoded IPFS URIs.
+    /// @param hook The hook from which to get tiers.
+    /// @param encodedIPFSUris The URIs to get tiers of.
+    /// @return tiers The tiers that correspond to the provided encoded IPFS URIs. Empty tiers are returned for URIs without a tier.
     function tiersFor(
         address hook,
         bytes32[] memory encodedIPFSUris
@@ -50,11 +71,20 @@ interface ICTPublisher {
         view
         returns (JB721Tier[] memory tiers);
 
+    /// @notice Configure the allowed criteria for publishing new NFTs to a hook.
+    /// @param allowedPosts An array of criteria for allowed posts.
     function configurePostingCriteriaFor(CTAllowedPost[] memory allowedPosts) external;
 
+    /// @notice Publish NFT posts and mint a first copy of each. A fee is taken for the fee project.
+    /// @param hook The hook to mint from.
+    /// @param posts An array of posts to publish as NFTs.
+    /// @param nftBeneficiary The beneficiary of the NFT mints.
+    /// @param feeBeneficiary The beneficiary of the fee project's tokens.
+    /// @param additionalPayMetadata Extra metadata bytes to include in the payment.
+    /// @param feeMetadata Metadata to send alongside the fee payment.
     function mintFrom(
         IJB721TiersHook hook,
-        CTPost[] memory posts,
+        CTPost[] calldata posts,
         address nftBeneficiary,
         address feeBeneficiary,
         bytes calldata additionalPayMetadata,


### PR DESCRIPTION
## Summary
- Fixed `posts` parameter in `ICTPublisher.mintFrom` from `memory` to `calldata` to match implementation
- Fixed bit range comment in `CTPublisher.sol`: "136-67" to "136-167" and "minimum" to "maximum"
- Fixed comment in `CTDeployer.sol`: "Otherwise, forward the call to the datahook" to "Forward the call to the data hook"
- Added full NatSpec documentation to `ICTDeployer.sol`, `ICTPublisher.sol`, and `ICTProjectOwner.sol`

## Test plan
- [ ] Verify `forge build` compiles cleanly
- [ ] Verify no functional changes were introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)